### PR TITLE
Local predictor

### DIFF
--- a/scripts/myop-predict.pl
+++ b/scripts/myop-predict.pl
@@ -52,11 +52,11 @@ if ($genome) {
 }
 
 if ($transcriptome) {
-  $predictor = abs_path(dirname(abs_path($0)) . "/../transcriptome/" . $transcriptome)
+  $predictor = abs_path(dirname(abs_path($0)) . "/../transcriptome/" . $transcriptome);
 }
 
 if ($localmodel) {
-  $predictor = $localmodel
+  $predictor = abs_path($localmodel);
 }
 
 # if(! defined ($predictor)){


### PR DESCRIPTION
O MYOP só fazia predições corretas (utilizando preditores locais) quando o usuário passava o caminho completo do preditor. Isso fazia sentido antigamente onde path completo era usado para um preditor local e nome simples para preditor da instalação. Agora que temos as flag `-l`, `-g` e `-t` isso já não é mais necessário.

Esse pull request corrige isso. Agora um simples: `myop-predict -l pasta-local -f seq.fa` funciona
